### PR TITLE
add mos.ru to dmarc whitelist

### DIFF
--- a/rspamd/dmarc_whitelist.inc
+++ b/rspamd/dmarc_whitelist.inc
@@ -40,6 +40,7 @@ megafon.ru
 mercadolibre.com.ar
 mercadolivre.com.br
 messenger.com
+mos.ru
 mvideo.ru
 neobux.com
 netflix.com


### PR DESCRIPTION
Mos.ru is a government website. They send out payment and other notifications. 
As they have a valid DMARC policy configured, please whitelist them.