### PR TITLE
Remove constantcontact.com

### DIFF
--- a/rspamd/spf_dkim_whitelist.inc
+++ b/rspamd/spf_dkim_whitelist.inc
@@ -53,7 +53,6 @@ change.org
 chase.com
 cisco.com
 citi.com
-constantcontact.com
 costco.com
 craigslist.org
 custhelp.com


### PR DESCRIPTION
This type of spam https://pastebin.com/5bMKJK9d is being sent to many users in our server.