### PR TITLE
Add e-boks.dk

### DIFF
--- a/rspamd/dmarc_whitelist_new.inc
+++ b/rspamd/dmarc_whitelist_new.inc
@@ -217,6 +217,7 @@ dsns.gov.ua
 dtv.gov
 dudley.gov.uk
 dyslexiaida.org
+e-boks.dk
 e-verify.gov
 eastdunbarton.gov.uk
 eaststaffsbc.gov.uk

--- a/rspamd/spf_dkim_whitelist.inc
+++ b/rspamd/spf_dkim_whitelist.inc
@@ -63,6 +63,7 @@ discovercard.com
 disqus.com
 dropbox.com
 drweb.com
+e-boks.dk
 ebay.ca
 ebay.com
 ebay.com.au


### PR DESCRIPTION
e-boks is used in Denmark for digital mail. From Danish Wikipedia:
https://translate.google.com/translate?sl=auto&tl=en&u=https%3A%2F%2Fda.wikipedia.org%2Fwiki%2FE-Boks