### PR TITLE
Add skanetrafiken.se

### DIFF
--- a/rspamd/spf_dkim_whitelist.inc
+++ b/rspamd/spf_dkim_whitelist.inc
@@ -169,6 +169,7 @@ researchgate.net
 salesforce.com
 sciencedirect.com
 shopify.com
+skanetrafiken.se
 slack.com
 slideshare.net
 so-net.ne.jp


### PR DESCRIPTION
Skånetrafiken is a transportation authority/operator for the region of
Skåne, Sweden.

It sends invoices for purchased tickets from this domain, so it is
important that they do not get miscategorised as spam.