### PR TITLE
Add minmyndighetspost.se

### DIFF
--- a/rspamd/spf_dkim_whitelist.inc
+++ b/rspamd/spf_dkim_whitelist.inc
@@ -129,6 +129,7 @@ mercadolivre.com.br
 messenger.com
 microsoft.com
 microsoftonline.com
+minmyndighetspost.se
 moikrug.ru
 mts.ru
 neobux.com


### PR DESCRIPTION
Minmyndighetspost is a digital mailbox service provided by the Swedish
government.