### PR TITLE
Add serpro.gov.br

### DIFF
--- a/rspamd/dmarc_whitelist_new.inc
+++ b/rspamd/dmarc_whitelist_new.inc
@@ -625,6 +625,7 @@ semnan.ac.ir
 senate.gov
 sendgrid.net bl:1
 seniorcorps.gov
+serpro.gov.br
 service.gov.uk
 sftool.gov
 shetland.gov.uk


### PR DESCRIPTION
SERPRO is the IT company for the Brazilian federal government.
Many government services use it for sending e-mails.