### PR TITLE
Add kivra.com

### DIFF
--- a/rspamd/dmarc_whitelist_new.inc
+++ b/rspamd/dmarc_whitelist_new.inc
@@ -390,6 +390,7 @@ kassy.ru
 kent.gov.uk
 kids.gov
 kingston.gov.uk
+kivra.com
 kpk.gov.pl
 lacoast.gov
 landsbanki.is


### PR DESCRIPTION
Kivra is a commercial Swedish service for digital post. [1]
It is the most popular of this kind in Sweden. [2]

[1] https://kivra.se/en/private
[2] https://sv.wikipedia.org/wiki/Digital_brevl%C3%A5da