### PR TITLE
Penalize spoofing of some Brazilian domains

### DIFF
--- a/rspamd/dmarc_whitelist_new.inc
+++ b/rspamd/dmarc_whitelist_new.inc
@@ -130,7 +130,7 @@ bromley.gov.uk
 bts.gov
 business.gov
 caerphilly.gov.uk
-caixa.gov.br
+caixa.gov.br both:1.0
 cambridge-news.co.uk
 campaign.gov.uk
 cancer.gov
@@ -166,7 +166,7 @@ colgate.com.br
 collegedrinkingprevention.gov
 companies-house.gov.uk
 comuneap.gov.it
-conab.gov.br
+conab.gov.br both:1.0
 concerts.com
 consultant.ru
 contact-sys.com
@@ -634,7 +634,7 @@ semnan.ac.ir
 senate.gov
 sendgrid.net bl:1
 seniorcorps.gov
-serpro.gov.br
+serpro.gov.br both:1.0
 service.gov.uk
 sftool.gov
 shetland.gov.uk
@@ -705,7 +705,7 @@ tradingstandards.gov.uk
 treas.gov
 trial-sport.ru
 tsa.gov
-tst.gov.br
+tst.gov.br both:1.0
 tuba.gov.tr
 turystyka.gov.pl
 tutu.ru
@@ -744,7 +744,7 @@ vigoda.ru
 visa.co.uk
 visa.com
 visa.com.ar
-visa.com.br
+visa.com.br both:1.0
 visa.com.cn
 visa.com.tw
 visa.pl


### PR DESCRIPTION
There was a recent data breach that revealed sensitive information for
220 million Brazilians [1]: names, addresses, social security numbers,
medical records, employment information, and more.

Due to this information now becoming public, phishing e-mails became way
more effective since they can be personalized and contain accurate
information about the recipient, giving the impression of being a legit
message sent by a bank or the government [2].

Therefore it becomes quite important that e-mail which is spoofing
legitimate senders is mistakenly classified as spam. This commit ensures
that if DMARC validation fails for such critical domains, the e-mail
is penalized accordingly.

[1] https://www.schneier.com/blog/archives/2021/01/massive-brazilian-data-breach.html
[2] The author of this commit was a recipient of such messages.