### PR TITLE
Remove libero.it from SPF/DKIM whitelist

### DIFF
--- a/rspamd/spf_dkim_whitelist.inc
+++ b/rspamd/spf_dkim_whitelist.inc
@@ -147,7 +147,6 @@ kijiji.ca
 kotaku.com
 lensa.com
 letsencrypt.org
-libero.it
 lifehacker.com
 likes.com
 linkedin.com


### PR DESCRIPTION
Removed 'libero.it' from the SPF/DKIM whitelist as this is freemail domain, and freemail domains cant be easily source of spam.